### PR TITLE
Add "adding models" vignette and re-work documentation configuration

### DIFF
--- a/R/analytiskontodimas_2004.R
+++ b/R/analytiskontodimas_2004.R
@@ -19,6 +19,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/ashrafi1_2018.R
+++ b/R/ashrafi1_2018.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/ashrafi2_2018.R
+++ b/R/ashrafi2_2018.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/ashrafi3_2018.R
+++ b/R/ashrafi3_2018.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/ashrafi4_2018.R
+++ b/R/ashrafi4_2018.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/ashrafi5_2018.R
+++ b/R/ashrafi5_2018.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/atkin_2005.R
+++ b/R/atkin_2005.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/beta_2012.R
+++ b/R/beta_2012.R
@@ -18,6 +18,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model difficult to fit.
+#' @concept model
 #' @examples
 #' \donttest{
 #' # load in ggplot

--- a/R/betatypesimplified_2008.R
+++ b/R/betatypesimplified_2008.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' \donttest{
 #' # load in ggplot

--- a/R/boatman_2017.R
+++ b/R/boatman_2017.R
@@ -17,7 +17,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
-#'
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/briere1.R
+++ b/R/briere1.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/briere1simplified_1999.R
+++ b/R/briere1simplified_1999.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/briere2_1999.R
+++ b/R/briere2_1999.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/briere2simplified_1999.R
+++ b/R/briere2simplified_1999.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/briereextended_2021.R
+++ b/R/briereextended_2021.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/briereextendedsimplified_2021.R
+++ b/R/briereextendedsimplified_2021.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/calc_params.R
+++ b/R/calc_params.R
@@ -17,6 +17,7 @@
 #' * skewness using [get_skewness()]
 #'
 #' @md
+#' @concept params
 #' @export calc_params
 
 calc_params <- function(model, ...){

--- a/R/data.R
+++ b/R/data.R
@@ -16,6 +16,7 @@
 #' @keywords dataset
 #' @docType data
 #' @usage data("chlorella_tpc")
+#' @concept data
 #' @examples
 #' data("chlorella_tpc")
 #' library(ggplot2)
@@ -39,6 +40,7 @@
 #' @keywords dataset
 #' @docType data
 #' @usage data("bacteria_tpc")
+#' @concept data
 #' @examples
 #' data("bacteria_tpc")
 #' library(ggplot2)

--- a/R/delong_2017.R
+++ b/R/delong_2017.R
@@ -19,6 +19,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/deutsch_2008.R
+++ b/R/deutsch_2008.R
@@ -18,6 +18,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/eubank_1973.R
+++ b/R/eubank_1973.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/flextpc_2024.R
+++ b/R/flextpc_2024.R
@@ -18,6 +18,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally this model requires larger iter values in nls_multstart to fit reliably.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/flinn_1991.R
+++ b/R/flinn_1991.R
@@ -15,7 +15,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
-#'
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/gaussian_1987.R
+++ b/R/gaussian_1987.R
@@ -15,6 +15,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/gaussianmodified_2006.R
+++ b/R/gaussianmodified_2006.R
@@ -17,7 +17,7 @@
 #' @note Generally we found this model difficult to fit.
 #'
 #' This function was previously called \code{modifiedgaussian_2006()} however this is now deprecated and will be removed in the future.
-#'
+#' @concept model
 #' @references Angilletta Jr, M. J. (2006). Estimating and comparing thermal performance curves. Journal of Thermal Biology, 31(7), 541-545.
 #' @examples
 #' # load in ggplot

--- a/R/get_breadth.R
+++ b/R/get_breadth.R
@@ -4,7 +4,7 @@
 #' @param level proportion of maximum rate over which thermal performance breadth is calculated
 #' @details Thermal performance breadth is calculated as the range of temperatures over which a curve's rate is at least 0.8 of peak. This defaults to a proportion of 0.8 but can be changed using the \code{level} argument.
 #' @return Numeric estimate of thermal performance breadth (in ºC)
-#'
+#' @concept params
 #' @export get_breadth
 
 get_breadth <- function(model, level = 0.8){

--- a/R/get_ctmax.R
+++ b/R/get_ctmax.R
@@ -3,6 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Critical thermal maximum is calculated by predicting over a temperature range 50 ºC beyond the maximum value in the dataset. The predicted rate value closest to 0 is then extracted. When this is impossible due to the curve formula (i.e the Sharpe-Schoolfield model), the temperature where the rate is 5 percent of the maximum rate is estimated. Predictions are done every 0.001 ºC so the estimate of the critical thermal maximum should be accurate up to 0.001 ºC.
 #' @return Numeric estimate of critical thermal maximum (ºC)
+#' @concept params
 #' @export get_ctmax
 
 get_ctmax <- function(model){

--- a/R/get_ctmin.R
+++ b/R/get_ctmin.R
@@ -3,7 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Optimum temperature is calculated by predicting over a temperature range 50 degrees lower than the minimum value in the dataset. The predicted rate value closest to 0 is then extracted. When this is impossible due to the curve formula (i.e the Sharpe-Schoolfield model), the temperature where the rate is 5 percent of the maximum rate is estimated. Predictions are done every 0.001 ºC value so the estimate of the critical thermal minimum should be accurate up to 0.001 ºC.
 #' @return Numeric estimate of critical thermal minimum (ºC)
-#'
+#' @concept params
 #' @export get_ctmin
 
 get_ctmin <- function(model){

--- a/R/get_e.R
+++ b/R/get_e.R
@@ -3,6 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Fits a modified-Boltzmann equation to all raw data below the optimum temperature (ºC; as estimated by \code{get_topt}).
 #' @return Numeric estimate of activation energy (eV)
+#' @concept params
 #' @export get_e
 
 get_e <- function(model){

--- a/R/get_eh.R
+++ b/R/get_eh.R
@@ -3,6 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Fits a modified-Boltzmann equation to all raw data beyond the optimum temperature (ºC; as estimated by \code{get_topt}).
 #' @return Numeric estimate of activation energy (eV)
+#' @concept params
 #' @export get_eh
 
 get_eh <- function(model){

--- a/R/get_lower_lims.R
+++ b/R/get_lower_lims.R
@@ -7,6 +7,7 @@
 #' @author Daniel Padfield
 #' @author Francis Windram
 #' @return Named list of lower limits given the data and model being fitted
+#' @concept helper
 #' @export get_lower_lims
 
 get_lower_lims <- function(x, y, model_name) {

--- a/R/get_model_names.R
+++ b/R/get_model_names.R
@@ -4,6 +4,7 @@
 #' @author Daniel Padfield
 #' @author Francis Windram
 #' @return character vector of thermal performance curves available in rTPC
+#' @concept helper
 #' @examples
 #' get_model_names()
 #' get_model_names("briere")

--- a/R/get_q10.R
+++ b/R/get_q10.R
@@ -3,6 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Fits the q10 portion of \code{rezende_2019} to all raw data below the optimum temperature (ºC; as estimated by \code{get_topt}).
 #' @return Numeric estimate of q10 value
+#' @concept params
 #' @export get_q10
 
 get_q10 <- function(model){

--- a/R/get_rmax.R
+++ b/R/get_rmax.R
@@ -3,6 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Maximum rate is calculated by predicting over the temperature range using the previously estimated parameters and picking the maximum rate value. Predictions are done every 0.001 ºC.
 #' @return Numeric estimate of maximum rate
+#' @concept params
 #' @export get_rmax
 
 get_rmax <- function(model){

--- a/R/get_skewness.R
+++ b/R/get_skewness.R
@@ -3,6 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Skewness is calculated from the values of activation energy (e) and deactivation energy (eh) as: skewness = e - eh. A negative skewness indicates the TPC is left skewed, the drop after the optimum is steeper than the rise up to the optimum. A positive skewness means that the TPC is right skewed and a value of 0 would mean the curve is symmetrical around the optimum.
 #' @return Numeric estimate of skewness
+#' @concept params
 #' @export get_skewness
 
 get_skewness <- function(model){

--- a/R/get_start_vals.R
+++ b/R/get_start_vals.R
@@ -7,6 +7,7 @@
 #' @author Daniel Padfield
 #' @author Francis Windram
 #' @return Named list of start parameters given the data and model being fitted
+#' @concept helper
 #' @export get_start_vals
 
 get_start_vals <- function(x, y, model_name) {

--- a/R/get_thermalsafetymargin.R
+++ b/R/get_thermalsafetymargin.R
@@ -3,7 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Thermal safety margin is calculated as: CTmax - Topt. This is calculated using the functions \code{get_ctmax} and \code{get_topt}.
 #' @return Numeric estimate of thermal safety margin (in ºC)
-#'
+#' @concept params
 #' @export get_thermalsafetymargin
 
 get_thermalsafetymargin <- function(model){

--- a/R/get_thermaltolerance.R
+++ b/R/get_thermaltolerance.R
@@ -3,7 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Thermal tolerance is calculated as: CTmax - CTmin. This is calculated using the functions \code{get_ctmax} and \code{get_ctmin}.
 #' @return Thermal tolerance (in ºC)
-#'
+#' @concept params
 #' @export get_thermaltolerance
 
 get_thermaltolerance <- function(model){

--- a/R/get_topt.R
+++ b/R/get_topt.R
@@ -3,7 +3,7 @@
 #' @param model nls model object that contains a model of a thermal performance curve
 #' @details Optimum temperature (ºC) is calculated by predicting over the temperature range using the previously estimated parameters and keeping the temperature where the largest rate value occurs. Predictions are done every 0.001 ºC so the estimate of optimum temperature should be accurate up to 0.001 ºC.
 #' @return Numeric estimate of optimum temperature (in ºC)
-#'
+#' @concept params
 #' @export get_topt
 
 get_topt <- function(model){

--- a/R/get_upper_lims.R
+++ b/R/get_upper_lims.R
@@ -7,6 +7,7 @@
 #' @author Daniel Padfield
 #' @author Francis Windram
 #' @return Named list of upper limits given the data and model being fitted
+#' @concept helper
 #' @export get_upper_lims
 
 get_upper_lims <- function(x, y, model_name) {

--- a/R/hinshelwood_1947.R
+++ b/R/hinshelwood_1947.R
@@ -18,6 +18,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model difficult to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/janisch1_1925.R
+++ b/R/janisch1_1925.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/janisch2_1925.R
+++ b/R/janisch2_1925.R
@@ -17,6 +17,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/joehnk_2008.R
+++ b/R/joehnk_2008.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @references Joehnk, Klaus D., et al. Summer heatwaves promote blooms of harmful cyanobacteria. Global change biology 14.3: 495-512 (2008)
 #' @examples
 #' # load in ggplot

--- a/R/johnsonlewin_1946.R
+++ b/R/johnsonlewin_1946.R
@@ -18,6 +18,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model difficult to fit.
+#' @concept model
 #' @examples
 #' \donttest{
 #' # load in ggplot

--- a/R/kamykowski_1985.R
+++ b/R/kamykowski_1985.R
@@ -16,7 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
-#'
+#' @concept model
 #' @references Kamykowski, Daniel. A survey of protozoan laboratory temperature studies applied to marine dinoflagellate behaviour from a field perspective. Contributions in Marine Science. (1985).
 #' @examples
 #' # load in ggplot

--- a/R/lactin2_1995.R
+++ b/R/lactin2_1995.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/lobry_1991.R
+++ b/R/lobry_1991.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/oneill_1972.R
+++ b/R/oneill_1972.R
@@ -19,6 +19,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @references O’Neill, R.V., Goldstein, R.A., Shugart, H.H., Mankin, J.B. Terrestrial Ecosystem Energy Model. Eastern Deciduous Forest Biome Memo Report Oak Ridge. The Environmental Sciences Division of the Oak Ridge National Laboratory. (1972)
 #' @examples
 #' # load in ggplot

--- a/R/pawar_2018.R
+++ b/R/pawar_2018.R
@@ -20,6 +20,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/quadratic_2008.R
+++ b/R/quadratic_2008.R
@@ -15,6 +15,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/ratkowsky_1983.R
+++ b/R/ratkowsky_1983.R
@@ -15,6 +15,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @references Ratkowsky, D.A., Lowry, R.K., McMeekin, T.A., Stokes, A.N., Chandler, R.E., Model for bacterial growth rate throughout the entire biokinetic temperature range. J. Bacteriol. 154: 1222–1226 (1983)
 #' @examples
 #' # load in ggplot

--- a/R/rezende_2019.R
+++ b/R/rezende_2019.R
@@ -18,6 +18,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/rosso_1993.R
+++ b/R/rosso_1993.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/sharpeschoolfull_1981.R
+++ b/R/sharpeschoolfull_1981.R
@@ -22,6 +22,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/sharpeschoolhigh_1981.R
+++ b/R/sharpeschoolhigh_1981.R
@@ -19,6 +19,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/sharpeschoollow_1981.R
+++ b/R/sharpeschoollow_1981.R
@@ -19,6 +19,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/spain_1982.R
+++ b/R/spain_1982.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or plucked from thin air.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/stinner_1974.R
+++ b/R/stinner_1974.R
@@ -18,6 +18,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/taylorsexton_1972.R
+++ b/R/taylorsexton_1972.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are based on extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/thomas_2012.R
+++ b/R/thomas_2012.R
@@ -15,6 +15,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based on extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/thomas_2017.R
+++ b/R/thomas_2017.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based on extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/R/tomlinsonphillips_2015.R
+++ b/R/tomlinsonphillips_2015.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model somewhat difficult to fit.
+#' @concept model
 #' @examples
 #' \donttest{
 #' # load in ggplot

--- a/R/warrendreyer_2006.R
+++ b/R/warrendreyer_2006.R
@@ -16,6 +16,7 @@
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based extreme values that are unlikely to occur in ecological settings.
 #'
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' \donttest{
 #' # load in ggplot

--- a/R/weibull_1995.R
+++ b/R/weibull_1995.R
@@ -16,6 +16,7 @@
 #'
 #' Limits in \code{get_lower_lims} and \code{get_upper_lims} are derived from the data or based  extreme values that are unlikely to occur in ecological settings.
 #' @note Generally we found this model easy to fit.
+#' @concept model
 #' @examples
 #' # load in ggplot
 #' library(ggplot2)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -41,77 +41,18 @@ articles:
   - adding_models
 reference:
 - title: Models
+  desc: TPC models for fitting.
   contents:
-  - analytiskontodimas_2004
-  - ashrafi1_2018
-  - ashrafi2_2018
-  - ashrafi3_2018
-  - ashrafi4_2018
-  - ashrafi5_2018
-  - atkin_2005
-  - beta_2012
-  - betatypesimplified_2008
-  - boatman_2017
-  - briere1_1999
-  - briere1simplified_1999
-  - briere2_1999
-  - briere2simplified_1999
-  - briereextended_2021
-  - briereextendedsimplified_2021
-  - delong_2017
-  - deutsch_2008
-  - eubank_1973
-  - flextpc_2024
-  - flinn_1991
-  - gaussian_1987
-  - gaussianmodified_2006
-  - hinshelwood_1947
-  - janisch1_1925
-  - janisch2_1925
-  - joehnk_2008
-  - johnsonlewin_1946
-  - kamykowski_1985
-  - lactin2_1995
-  - lobry_1991
-  - oneill_1972
-  - pawar_2018
-  - quadratic_2008
-  - ratkowsky_1983
-  - rezende_2019
-  - rosso_1993
-  - sharpeschoolfull_1981
-  - sharpeschoolhigh_1981
-  - sharpeschoollow_1981
-  - spain_1982
-  - stinner_1974
-  - taylorsexton_1972
-  - thomas_2012
-  - thomas_2017
-  - tomlinsonphillips_2015
-  - warrendreyer_2006
-  - weibull_1995
+  - has_concept("model")
 - title: Helper functions
+  desc: Functions to aid in generating starting values or limits.
   contents:
-  - get_model_names
-  - get_start_vals
-  - get_lower_lims
-  - get_upper_lims
+  - has_concept("helper")
 - title: Calculating parameters
+  desc: Functions for calculating parameters of interest.
   contents:
-  - calc_params
-  - get_ctmax
-  - get_ctmin
-  - get_e
-  - get_eh
-  - get_q10
-  - get_rmax
-  - get_skewness
-  - get_thermalsafetymargin
-  - get_thermaltolerance
-  - get_breadth
-  - get_topt
+  - has_concept("params")
 - title: Data
   contents:
-  - bacteria_tpc
-  - chlorella_tpc
+  - has_concept("data")
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,6 @@
 template:
   bootstrap: 5
+  light-switch: true
   bootswatch: cosmo
   math-rendering: mathjax
   bslib:
@@ -34,6 +35,10 @@ articles:
   contents:
   - fit_many_curves
   - bootstrapping_many_curves
+- title: Contributing to rTPC
+  navbar: Contributing to rTPC
+  contents:
+  - adding_models
 reference:
 - title: Models
   contents:

--- a/man/analytiskontodimas_2004.Rd
+++ b/man/analytiskontodimas_2004.Rd
@@ -77,3 +77,4 @@ criteria. Environ. Entomol. 33, 1–11 (2004).
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/ashrafi1_2018.Rd
+++ b/man/ashrafi1_2018.Rd
@@ -73,3 +73,4 @@ Ashrafi, R. et al. Broad thermal tolerance is negatively correlated with virulen
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/ashrafi2_2018.Rd
+++ b/man/ashrafi2_2018.Rd
@@ -73,3 +73,4 @@ Ashrafi, R. et al. Broad thermal tolerance is negatively correlated with virulen
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/ashrafi3_2018.Rd
+++ b/man/ashrafi3_2018.Rd
@@ -73,3 +73,4 @@ Ashrafi, R. et al. Broad thermal tolerance is negatively correlated with virulen
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/ashrafi4_2018.Rd
+++ b/man/ashrafi4_2018.Rd
@@ -75,3 +75,4 @@ Ashrafi, R. et al. Broad thermal tolerance is negatively correlated with virulen
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/ashrafi5_2018.Rd
+++ b/man/ashrafi5_2018.Rd
@@ -75,3 +75,4 @@ Ashrafi, R. et al. Broad thermal tolerance is negatively correlated with virulen
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/atkin_2005.Rd
+++ b/man/atkin_2005.Rd
@@ -73,3 +73,4 @@ Atkin, OK, Bruhn D, Tjoelker MG. Response of Plant Respiration to Changes in Tem
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/bacteria_tpc.Rd
+++ b/man/bacteria_tpc.Rd
@@ -30,4 +30,5 @@ ggplot(bacteria_tpc) +
 \references{
 Padfield, D., Castledine, M., & Buckling, A. (2020). Temperature-dependent changes to host–parasite interactions alter the thermal performance of a bacterial host. The ISME Journal, 14(2), 389-398.
 }
+\concept{data}
 \keyword{dataset}

--- a/man/beta_2012.Rd
+++ b/man/beta_2012.Rd
@@ -79,3 +79,4 @@ Niehaus, Amanda C., et al. Predicting the physiological performance of ectotherm
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/betatypesimplified_2008.Rd
+++ b/man/betatypesimplified_2008.Rd
@@ -75,3 +75,4 @@ Damos, P. & Savopoulou-Soultani, M. Temperature-dependent bionomics and modeling
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/boatman_2017.Rd
+++ b/man/boatman_2017.Rd
@@ -74,3 +74,4 @@ theme_bw()
 \references{
 Boatman, T. G., Lawson, T., & Geider, R. J. A key marine diazotroph in a changing ocean: The interacting effects of temperature, CO2 and light on the growth of Trichodesmium erythraeum IMS101. PLoS ONE, 12, e0168796 (2017)
 }
+\concept{model}

--- a/man/briere1_1999.Rd
+++ b/man/briere1_1999.Rd
@@ -73,3 +73,4 @@ Brière, J.F., Pracros, P., Le Roux, A.Y., Pierre, J.S.,  A novel rate model of 
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/briere1simplified_1999.Rd
+++ b/man/briere1simplified_1999.Rd
@@ -73,3 +73,4 @@ Brière, J.F., Pracros, P., Le Roux, A.Y., Pierre, J.S.,  A novel rate model of 
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/briere2_1999.Rd
+++ b/man/briere2_1999.Rd
@@ -72,3 +72,4 @@ theme_bw()
 \references{
 Brière, J.F., Pracros, P., Le Roux, A.Y., Pierre, J.S.,  A novel rate model of temperature-dependent development for arthropods. Environmental Entomololgy, 28, 22–29 (1999)
 }
+\concept{model}

--- a/man/briere2simplified_1999.Rd
+++ b/man/briere2simplified_1999.Rd
@@ -72,3 +72,4 @@ theme_bw()
 \references{
 Brière, J.F., Pracros, P., Le Roux, A.Y., Pierre, J.S.,  A novel rate model of temperature-dependent development for arthropods. Environmental Entomololgy, 28, 22–29 (1999)
 }
+\concept{model}

--- a/man/briereextended_2021.Rd
+++ b/man/briereextended_2021.Rd
@@ -74,3 +74,4 @@ theme_bw()
 \references{
 Cruz-Loya, M. et al. Antibiotics shift the temperature response curve of Escherichia coli growth. mSystems 6, e00228–21 (2021).
 }
+\concept{model}

--- a/man/briereextendedsimplified_2021.Rd
+++ b/man/briereextendedsimplified_2021.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Cruz-Loya, M. et al. Antibiotics shift the temperature response curve of Escherichia coli growth. mSystems 6, e00228–21 (2021).
 }
+\concept{model}

--- a/man/calc_params.Rd
+++ b/man/calc_params.Rd
@@ -33,3 +33,4 @@ Currently estimates:
 \item skewness using \code{\link[=get_skewness]{get_skewness()}}
 }
 }
+\concept{params}

--- a/man/chlorella_tpc.Rd
+++ b/man/chlorella_tpc.Rd
@@ -34,4 +34,5 @@ ggplot(chlorella_tpc) +
 \references{
 Padfield, D., Yvon-durocher, G., Buckling, A., Jennings, S. & Yvon-durocher, G. (2015). Rapid evolution of metabolic traits explains thermal adaptation in phytoplankton, Ecology Letters, 19, 133-142.
 }
+\concept{data}
 \keyword{dataset}

--- a/man/delong_2017.Rd
+++ b/man/delong_2017.Rd
@@ -76,3 +76,4 @@ theme_bw()
 \references{
 DeLong, John P., et al. The combined effects of reactant kinetics and enzyme stability explain the temperature dependence of metabolic rates. Ecology and evolution 7.11 (2017): 3940-3950.
 }
+\concept{model}

--- a/man/deutsch_2008.Rd
+++ b/man/deutsch_2008.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Deutsch, C. A., Tewksbury, J. J., Huey, R. B., Sheldon, K. S., Ghalambor, C. K., Haak, D. C., & Martin, P. R. Impacts of climate warming on terrestrial ectotherms across latitude. Proceedings of the National Academy of Sciences, 105(18), 6668-6672. (2008)
 }
+\concept{model}

--- a/man/eubank_1973.Rd
+++ b/man/eubank_1973.Rd
@@ -74,3 +74,4 @@ Eubank, W. P., Atmar, J. W. & Ellington, J. J. The significance and thermodynami
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/flextpc_2024.Rd
+++ b/man/flextpc_2024.Rd
@@ -77,3 +77,4 @@ Cruz-Loya M, Mordecai EA, Savage VM. A flexible model for thermal performance cu
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/flinn_1991.Rd
+++ b/man/flinn_1991.Rd
@@ -70,3 +70,4 @@ theme_bw()
 \references{
 Flinn PW Temperature-dependent functional response of the parasitoid Cephalonomia waterstoni (Gahan) (Hymenoptera, Bethylidae) attacking rusty grain beetle larvae (Coleoptera, Cucujidae). Environmental Entomology, 20, 872–876, (1991)
 }
+\concept{model}

--- a/man/gaussian_1987.Rd
+++ b/man/gaussian_1987.Rd
@@ -71,3 +71,4 @@ theme_bw()
 \references{
 Lynch, M., Gabriel, W., Environmental tolerance. The American Naturalist. 129, 283–303. (1987)
 }
+\concept{model}

--- a/man/gaussianmodified_2006.Rd
+++ b/man/gaussianmodified_2006.Rd
@@ -76,3 +76,4 @@ theme_bw()
 \references{
 Angilletta Jr, M. J. (2006). Estimating and comparing thermal performance curves. Journal of Thermal Biology, 31(7), 541-545.
 }
+\concept{model}

--- a/man/get_breadth.Rd
+++ b/man/get_breadth.Rd
@@ -20,3 +20,4 @@ Estimate thermal performance breadth of a thermal performance curve
 \details{
 Thermal performance breadth is calculated as the range of temperatures over which a curve's rate is at least 0.8 of peak. This defaults to a proportion of 0.8 but can be changed using the \code{level} argument.
 }
+\concept{params}

--- a/man/get_ctmax.Rd
+++ b/man/get_ctmax.Rd
@@ -18,3 +18,4 @@ Estimate the critical thermal maximum of a thermal performance curve
 \details{
 Critical thermal maximum is calculated by predicting over a temperature range 50 ºC beyond the maximum value in the dataset. The predicted rate value closest to 0 is then extracted. When this is impossible due to the curve formula (i.e the Sharpe-Schoolfield model), the temperature where the rate is 5 percent of the maximum rate is estimated. Predictions are done every 0.001 ºC so the estimate of the critical thermal maximum should be accurate up to 0.001 ºC.
 }
+\concept{params}

--- a/man/get_ctmin.Rd
+++ b/man/get_ctmin.Rd
@@ -18,3 +18,4 @@ Estimate the critical thermal minimum of a thermal performance curve
 \details{
 Optimum temperature is calculated by predicting over a temperature range 50 degrees lower than the minimum value in the dataset. The predicted rate value closest to 0 is then extracted. When this is impossible due to the curve formula (i.e the Sharpe-Schoolfield model), the temperature where the rate is 5 percent of the maximum rate is estimated. Predictions are done every 0.001 ºC value so the estimate of the critical thermal minimum should be accurate up to 0.001 ºC.
 }
+\concept{params}

--- a/man/get_e.Rd
+++ b/man/get_e.Rd
@@ -18,3 +18,4 @@ Estimate the activation energy of a thermal performance curve
 \details{
 Fits a modified-Boltzmann equation to all raw data below the optimum temperature (ºC; as estimated by \code{get_topt}).
 }
+\concept{params}

--- a/man/get_eh.Rd
+++ b/man/get_eh.Rd
@@ -18,3 +18,4 @@ Estimate the deactivation energy of a thermal performance curve
 \details{
 Fits a modified-Boltzmann equation to all raw data beyond the optimum temperature (ºC; as estimated by \code{get_topt}).
 }
+\concept{params}

--- a/man/get_lower_lims.Rd
+++ b/man/get_lower_lims.Rd
@@ -24,3 +24,4 @@ Daniel Padfield
 
 Francis Windram
 }
+\concept{helper}

--- a/man/get_model_names.Rd
+++ b/man/get_model_names.Rd
@@ -26,3 +26,4 @@ Daniel Padfield
 
 Francis Windram
 }
+\concept{helper}

--- a/man/get_q10.Rd
+++ b/man/get_q10.Rd
@@ -18,3 +18,4 @@ Estimate the q10 value of a thermal performance curve
 \details{
 Fits the q10 portion of \code{rezende_2019} to all raw data below the optimum temperature (ºC; as estimated by \code{get_topt}).
 }
+\concept{params}

--- a/man/get_rmax.Rd
+++ b/man/get_rmax.Rd
@@ -18,3 +18,4 @@ Estimate maximum rate of a thermal performance curve
 \details{
 Maximum rate is calculated by predicting over the temperature range using the previously estimated parameters and picking the maximum rate value. Predictions are done every 0.001 ºC.
 }
+\concept{params}

--- a/man/get_skewness.Rd
+++ b/man/get_skewness.Rd
@@ -18,3 +18,4 @@ Estimates skewness of a thermal performance curve
 \details{
 Skewness is calculated from the values of activation energy (e) and deactivation energy (eh) as: skewness = e - eh. A negative skewness indicates the TPC is left skewed, the drop after the optimum is steeper than the rise up to the optimum. A positive skewness means that the TPC is right skewed and a value of 0 would mean the curve is symmetrical around the optimum.
 }
+\concept{params}

--- a/man/get_start_vals.Rd
+++ b/man/get_start_vals.Rd
@@ -24,3 +24,4 @@ Daniel Padfield
 
 Francis Windram
 }
+\concept{helper}

--- a/man/get_thermalsafetymargin.Rd
+++ b/man/get_thermalsafetymargin.Rd
@@ -18,3 +18,4 @@ Estimate thermal safety margin of a thermal performance curve
 \details{
 Thermal safety margin is calculated as: CTmax - Topt. This is calculated using the functions \code{get_ctmax} and \code{get_topt}.
 }
+\concept{params}

--- a/man/get_thermaltolerance.Rd
+++ b/man/get_thermaltolerance.Rd
@@ -18,3 +18,4 @@ Estimate thermal tolerance of a thermal performance curve
 \details{
 Thermal tolerance is calculated as: CTmax - CTmin. This is calculated using the functions \code{get_ctmax} and \code{get_ctmin}.
 }
+\concept{params}

--- a/man/get_topt.Rd
+++ b/man/get_topt.Rd
@@ -18,3 +18,4 @@ Estimate optimum temperature of a thermal performance curve
 \details{
 Optimum temperature (ºC) is calculated by predicting over the temperature range using the previously estimated parameters and keeping the temperature where the largest rate value occurs. Predictions are done every 0.001 ºC so the estimate of optimum temperature should be accurate up to 0.001 ºC.
 }
+\concept{params}

--- a/man/get_upper_lims.Rd
+++ b/man/get_upper_lims.Rd
@@ -24,3 +24,4 @@ Daniel Padfield
 
 Francis Windram
 }
+\concept{helper}

--- a/man/hinshelwood_1947.Rd
+++ b/man/hinshelwood_1947.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Hinshelwood C.N. The Chemical Kinetics of the Bacterial Cell. Oxford University Press. (1947)
 }
+\concept{model}

--- a/man/janisch1_1925.Rd
+++ b/man/janisch1_1925.Rd
@@ -74,3 +74,4 @@ Janisch, E. Über die Temperaturabhängigkeit biologischer Vorgänge und ihre ku
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/janisch2_1925.Rd
+++ b/man/janisch2_1925.Rd
@@ -76,3 +76,4 @@ Janisch, E. Über die Temperaturabhängigkeit biologischer Vorgänge und ihre ku
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/joehnk_2008.Rd
+++ b/man/joehnk_2008.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Joehnk, Klaus D., et al. Summer heatwaves promote blooms of harmful cyanobacteria. Global change biology 14.3: 495-512 (2008)
 }
+\concept{model}

--- a/man/johnsonlewin_1946.Rd
+++ b/man/johnsonlewin_1946.Rd
@@ -78,3 +78,4 @@ theme_bw()
 \references{
 Johnson, Frank H., and Isaac Lewin. The growth rate of E. coli in relation to temperature, quinine and coenzyme. Journal of Cellular and Comparative Physiology 28.1 (1946): 47-75.
 }
+\concept{model}

--- a/man/kamykowski_1985.Rd
+++ b/man/kamykowski_1985.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Kamykowski, Daniel. A survey of protozoan laboratory temperature studies applied to marine dinoflagellate behaviour from a field perspective. Contributions in Marine Science. (1985).
 }
+\concept{model}

--- a/man/lactin2_1995.Rd
+++ b/man/lactin2_1995.Rd
@@ -73,3 +73,4 @@ theme_bw()
 \references{
 Lactin, D.J., Holliday, N.J., Johnson, D.L. & Craigen, R. Improved rate models of temperature-dependent development by arthropods. Environmental Entomology 24, 69-75 (1995)
 }
+\concept{model}

--- a/man/lobry_1991.Rd
+++ b/man/lobry_1991.Rd
@@ -75,3 +75,4 @@ Lobry, J. R., Rosso, L., & Flandrois, J. P. (1991). A FORTRAN subroutine for the
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/oneill_1972.Rd
+++ b/man/oneill_1972.Rd
@@ -77,3 +77,4 @@ theme_bw()
 \references{
 O’Neill, R.V., Goldstein, R.A., Shugart, H.H., Mankin, J.B. Terrestrial Ecosystem Energy Model. Eastern Deciduous Forest Biome Memo Report Oak Ridge. The Environmental Sciences Division of the Oak Ridge National Laboratory. (1972)
 }
+\concept{model}

--- a/man/pawar_2018.Rd
+++ b/man/pawar_2018.Rd
@@ -82,3 +82,4 @@ Kontopoulos, Dimitrios - Georgios, Bernardo García-Carreras, Sofía Sal, Thomas
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/quadratic_2008.Rd
+++ b/man/quadratic_2008.Rd
@@ -71,3 +71,4 @@ theme_bw()
 \references{
 Montagnes, David JS, et al. Short‐term temperature change may impact freshwater carbon flux: a microbial perspective. Global Change Biology 14.12: 2823-2838. (2008)
 }
+\concept{model}

--- a/man/ratkowsky_1983.Rd
+++ b/man/ratkowsky_1983.Rd
@@ -73,3 +73,4 @@ theme_bw()
 \references{
 Ratkowsky, D.A., Lowry, R.K., McMeekin, T.A., Stokes, A.N., Chandler, R.E., Model for bacterial growth rate throughout the entire biokinetic temperature range. J. Bacteriol. 154: 1222–1226 (1983)
 }
+\concept{model}

--- a/man/rezende_2019.Rd
+++ b/man/rezende_2019.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Rezende, Enrico L., and Francisco Bozinovic. Thermal performance across levels of biological organization. Philosophical Transactions of the Royal Society B 374.1778 (2019): 20180549.
 }
+\concept{model}

--- a/man/rosso_1993.Rd
+++ b/man/rosso_1993.Rd
@@ -78,3 +78,4 @@ Rosso, L., Lobry, J. R., & Flandrois, J. P.  An unexpected correlation between c
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/sharpeschoolfull_1981.Rd
+++ b/man/sharpeschoolfull_1981.Rd
@@ -85,3 +85,4 @@ Schoolfield, R. M., Sharpe, P. J. & Magnuson, C. E. Non-linear regression of bio
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/sharpeschoolhigh_1981.Rd
+++ b/man/sharpeschoolhigh_1981.Rd
@@ -81,3 +81,4 @@ Schoolfield, R. M., Sharpe, P. J. & Magnuson, C. E. Non-linear regression of bio
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/sharpeschoollow_1981.Rd
+++ b/man/sharpeschoollow_1981.Rd
@@ -81,3 +81,4 @@ Schoolfield, R. M., Sharpe, P. J. & Magnuson, C. E. Non-linear regression of bio
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/spain_1982.Rd
+++ b/man/spain_1982.Rd
@@ -73,3 +73,4 @@ theme_bw()
 \references{
 BASIC Microcomputer Models in Biology. Addison-Wesley, Reading, MA. 1982
 }
+\concept{model}

--- a/man/stinner_1974.Rd
+++ b/man/stinner_1974.Rd
@@ -77,3 +77,4 @@ Stinner, R. E., Gutierrez, A. P., & Butler Jr, G. D. (1974). An algorithm for te
 \author{
 Daniel Padfield
 }
+\concept{model}

--- a/man/taylorsexton_1972.Rd
+++ b/man/taylorsexton_1972.Rd
@@ -74,3 +74,4 @@ Taylor, S. E. & Sexton, O. J. Some implications of leaf tearing in Musaceae. Eco
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/thomas_2012.Rd
+++ b/man/thomas_2012.Rd
@@ -73,3 +73,4 @@ theme_bw()
 \references{
 Thomas, Mridul K., et al. A global pattern of thermal adaptation in marine phytoplankton. Science 338.6110, 1085-1088 (2012)
 }
+\concept{model}

--- a/man/thomas_2017.Rd
+++ b/man/thomas_2017.Rd
@@ -75,3 +75,4 @@ theme_bw()
 \references{
 Thomas, Mridul K., et al. Temperature–nutrient interactions exacerbate sensitivity to warming in phytoplankton. Global change biology 23.8 (2017): 3269-3280.
 }
+\concept{model}

--- a/man/tomlinsonphillips_2015.Rd
+++ b/man/tomlinsonphillips_2015.Rd
@@ -75,3 +75,4 @@ Tomlinson, S. & Phillips, R. D. Differences in metabolic rate and evaporative wa
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/warrendreyer_2006.Rd
+++ b/man/warrendreyer_2006.Rd
@@ -75,3 +75,4 @@ Warren, C. R. & Dreyer, E. Temperature response of photosynthesis and internal c
 \author{
 Francis Windram
 }
+\concept{model}

--- a/man/weibull_1995.Rd
+++ b/man/weibull_1995.Rd
@@ -73,3 +73,4 @@ theme_bw()
 \references{
 Angilletta Jr, Michael J. Estimating and comparing thermal performance curves. Journal of Thermal Biology 31.7 (2006): 541-545.
 }
+\concept{model}

--- a/vignettes/adding_models.Rmd
+++ b/vignettes/adding_models.Rmd
@@ -1,0 +1,462 @@
+---
+title: "Adding Models to rTPC"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Adding Models to rTPC}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+So you want to contribute a model to rTPC? That's awesome!
+
+Here we will go through all the major steps for creating and contributing a model to rTPC.
+
+This vignette assumes that you have a working knowledge of basic git usage (either through the terminal, the RStudio interface, or another GUI), of R, and a functional knowledge of thermal performance curves.
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+```{r runtimer, include=FALSE}
+runstart <- lubridate::now()
+```
+
+## First steps
+
+The first thing you want to do when you have a model that is potentially useful in rTPC is to _check whether it's already there_!
+
+rTPC already contains many models designed on a variety of different data. It is quite likely at this point that there is a similar (or identical) model that already serves the same purpose. So why not save yourself the work if you can?
+
+### Forking the repository
+
+The easiest way to start working on rTPC is to **fork** the repo. [Github has some excellent instructions on doing this](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+
+Working on a fork of the repository will allow you to commit to rTPC as if it is your own project, and then contribute those commits back to the main repository through a **pull request**.
+
+### Setting up your workspace and R installation
+
+It is _strongly_ suggested that you install all packages from the "Suggests" section of rTPC (easily found in the DESCRIPTION file), alongside the packages `devtools` and `usethis` (see [here](https://r-pkgs.org/setup.html) for a deeper explanation of these packages).
+
+Once you have done this, git clone from YOUR fork of rTPC into a folder of your choice, and then open up the `rTPC.Rproj` file if you are using RStudio.
+
+## Adding a model
+
+Adding a model to rTPC consists of 4 major steps:
+
+1. Add the model code, starting values, and limits.
+2. Add the test file.
+3. Add the model to the rTPC database.
+4. Clean up, check, and add to documentation
+
+Models are generally named according to the scheme `authormodifier#_YYYY`. So a model by authors called King and Bishop published in 1992 would usually be codified as `kingbishop_1992`. If they further proposed a modified model, and a simplified version of each in the original paper, those would probably appear as `kingbishopmodified_1992`, `kingbishopsimplified_1992` and `kingbishopmodifiedsimplified_1992`. If there are many authors, or another better description of the model then initialisms or other descriptors can be used, but these may be changed if the package maintainers deem it to be confusing.
+
+### The model
+
+For this example, let's implement the Eubank model from [The Significance and Thermodynamics of Fluctuating Versus Static Thermal Environments on _Heliothis zea_ Egg Development Rates](https://academic.oup.com/ee/article/2/4/491/2480483).
+
+This model (eq4) is originally derived just for a bollworm, with some magic numbers:
+
+$$R(T) = \frac{800}{(T-91)^2+432}$$
+
+As a generalisation, we know from looking at the paper that $T_{opt} = 91$, and the numbers 800 and 432 are species-specific (and thus should be fit).
+
+As such we can reformulate the equation as:
+
+$$R(T) = \frac{a}{(T-T_{opt})^2+b}$$
+
+Where $a$ and $b$ are arbitrary parameters for fitting, and $T_{opt}$ can be at least approximated from the data.
+
+### The model file
+
+The model itself lives in a file named after the function, in the `R` directory. In our case that will be `eubank_1973.R`.
+
+You can create one using the function `usethis::use_r("eubank_1973")`
+
+Within this file are 4 functions:
+
+- `eubank_1973()` - The model itself
+- `eubank_1973.starting_vals()` - The starting values
+- `eubank_1973.lower_lims()` - The lower limits
+- `eubank_1973.upper_lims()` - The upper limits
+
+It is _very important_ that the auxiliary functions are named in this manner, otherwise the unified starting value/limit dispatch will not function correctly.
+
+#### The model function - `eubank_1973()`
+
+First of all we must implement the actual model itself (i.e. the equation above, but as R code).
+
+```{r echo=TRUE, eval=FALSE}
+eubank_1973 <- function(temp, topt, a, b){
+  est <- a / ((temp - topt)^2 + b)
+  return(est)
+}
+```
+
+A model function takes the parameters to fit the model as arguments, with temperature being the first by convention, and returns the estimates of the trait value at the given temperatures and parameter values.
+
+#### The starting values - `eubank_1973.starting_vals()`
+
+Deciding sensible starting values is truly a dark art. In many cases these are fairly arbitrary, though in certain cases an estimate can be obtained from the data.
+
+Starting values functions are always passed a dataframe called `d`, which will contain only the temperature and trait values for the given curve:
+
+```{r}
+# A slightly compressed example of how d is generated
+library(rTPC)
+subs <- subset(chlorella_tpc, chlorella_tpc$curve_id == 1)
+d <- data.frame(x=subs$temp, y=subs$rate, stringsAsFactors = FALSE)
+d <- d[order(d$x),]
+d
+```
+
+Every `model.starting_values()` function has the same approximate form, taking `d` as the only argument, and returning a named list of starting values. So in our case:
+
+```{r, echo=TRUE, eval=FALSE}
+eubank_1973.starting_vals <- function(d){
+  # starting values go here
+  return(c(topt=topt, a=a, b=b))
+}
+```
+
+
+In the case of the eubank model, $a$ and $b$ are arbitrary. As such we can take fairly sensible values at approximately the right magnitude (say $a = 300$ and $b = 50$).
+
+$T_{opt}$ on the other hand is a value that we can derive from our data, in this case it's the temperature at which $R$ is at its maximum.
+
+So lets put that together in our starting_vals function
+
+```{r}
+eubank_1973.starting_vals <- function(d){
+  rmax = max(d$y, na.rm = TRUE)  # Find max trait value
+  topt = mean(d$x[d$y == rmax])  # Find T of rmax
+  a = 300
+  b = 50
+  return(c(topt=topt, a=a, b=b))
+}
+```
+
+To reiterate an earlier point, it is _essential_ that the starting values function is named appropriately, e.g. `eubank_1973.starting_vals()`.
+
+The following _will not and can not work_:
+- `eubank_1973.startingvals()`
+- `eubank_1973.start_vals()`
+- `eubank_1973_starting_vals()`
+- `.starting_vals()`
+- `model.starting_vals()`
+
+#### The limits - `eubank_1973.lower_lims()` & `eubank_1973.upper_lims()`
+
+NLLS fitting often fails when unconstrained (as it may take one parameter to infinity and ignore all others). Even specifying absurdly large or infinite limits can make the optimiser behave better.
+
+As such, we must provide realistic bounds on the upper and lower limits of each parameter.
+
+These take the same functional form as the `starting_vals` function, requiring one argument (`d`) and returning a named list.
+
+Generally speaking it is best to keep limits fairly wide unless there is a good biological reason to do otherwise.
+
+For instance at the most $T_{opt}$ is never going to be above about 150°C, and likely will be a lot lower. And at its lower bound it is unlikely for the optimal trait value to occur at temperatures below 0°C. That gives us some fairly reasonable bounds for the values of $T_{opt}$.
+
+$a$ and $b$, however, are arbitrary values. Just by looking at the functional form of the model we can see that if $a$ goes to or below 0, or $b = 0-(T-T_{opt})$ then we will end up with fairly nonsensical answers (either negative trait values or undefined results), so we can bound those both on the low end at 0 to be safe. 
+
+In terms of upper limits, we have no real idea of how large those values may go (as they will be proportional to the units of the trait), so we can't set any reasonable bounds aside from `Inf`.
+
+To put that together, here are the lower and upper limit functions for `eubank_1976`:
+
+```{r}
+eubank_1973.lower_lims <- function(d){
+  topt = 0
+  a = 0
+  b = 0
+  return(c(topt=topt, a=a, b=b))
+}
+
+eubank_1973.upper_lims <- function(d){
+  topt = 150
+  a = Inf
+  b = Inf
+  return(c(topt=topt, a=a, b=b))
+}
+```
+
+#### The documentation
+
+rTPC leverages `roxygen2` for documentation. Each file contains documentation definitions at the **top of the file** in special comments starting `#'`.
+
+The best way to implement these is to copy from another model file (such as `atkin_2005`) and modify it to suit your own needs.
+
+Things to modify:
+- The first line description
+- parameters
+- author
+- reference
+- equation
+- note (if poorly fitting)
+- examples
+- export directive (this _must_ match the name of the model! The starting value and limit functions do not need exporting)
+
+### The model database
+
+Once you have created a model file, you need to add this model to rTPC's database of model names, so it knows that the model is available.
+
+This simply requires modifying the `mod_names` vector within the `get_model_names.R` file to include your new model. Make sure that the model name is exactly the same as that in your original file, and that it is enclosed in quotes!
+
+### Testing the model
+
+Now that the model is set up, the next port of call is to simply run the integration test.
+
+This is located in the `tests/testthat/test-startingvalues.R`
+
+It should provide a result somewhat like.
+```
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3 ]
+```
+
+If the test failed, the output is instead more like this:
+
+```
+[ FAIL 3 | WARN 0 | SKIP 0 | PASS 0 ]
+
+── Failure (test-startingvalues.R:42:3): All models can generate starting values ──
+length(mod_names) not equal to `starting_count`.
+1/1 mismatches
+[1] 48 - 47 == 1
+No starting values for:
+ ebank_1973
+
+── Failure (test-startingvalues.R:46:3): All models can generate lower limits ──
+length(mod_names) not equal to `lower_count`.
+1/1 mismatches
+[1] 48 - 47 == 1
+No lower limits for:
+ ebank_1973
+
+── Failure (test-startingvalues.R:50:3): All models can generate upper limits ──
+length(mod_names) not equal to `upper_count`.
+1/1 mismatches
+[1] 48 - 47 == 1
+No upper limits for:
+ ebank_1973
+[ FAIL 3 | WARN 0 | SKIP 0 | PASS 0 ]
+```
+
+In this case we can see that I simply misspelled the name of the model in the `get_model_names.R` file, so need to change that.
+
+If only one test of the three failed, that is likely an issue with the names of the functions in the actual model file.
+
+### The model test file
+
+Each model requires a model test, to make sure that changes in the future do not cause major fitting issues. These test files live in the `tests/testthat` directory.
+
+Creating a new one in RStudio is easy! Just make sure you have your model file in the script window, then run the command `usethis::use_test()`.
+
+This will create a new test file, in our case `tests/testthat/test-eubank_1973.R`
+
+Tests are mostly boilerplate, however there are a few things that do need to be changed, so again you can copy most of the code from another test file, such as `test-atkin_2005.R`.
+
+The main items to be changed are:
+- The model name throughout (5 occurrences)
+- The model arguments within `nls_multstart`
+- The `iter` argument to `nls_multstart` (this should be something like c(3,3,3,3) for a model with 4 free parameters)
+
+So the final test file will look something like this:
+
+```{r echo=TRUE, eval=FALSE}
+# do not run the test on CRAN as they take too long
+testthat::skip_on_cran()
+
+# method: fit model and get predictions. Check these against others.
+
+# load in ggplot
+library(ggplot2)
+
+# subset for the first TPC curve
+data('chlorella_tpc')
+d <- subset(chlorella_tpc, curve_id == 1)
+
+# get start values and fit model
+start_vals <- get_start_vals(d$temp, d$rate, model_name = 'eubank_1973')
+
+# fit model
+mod <- nls.multstart::nls_multstart(rate~eubank_1973(temp = temp, tops, a, b),
+                                    data = d,
+                                    iter = c(3,3,3),
+                                    start_lower = start_vals - 10,
+                                    start_upper = start_vals + 10,
+                                    lower = get_lower_lims(d$temp, d$rate, model_name = 'eubank_1973'),
+                                    upper = get_upper_lims(d$temp, d$rate, model_name = 'eubank_1973'),
+                                    supp_errors = 'Y',
+                                    convergence_count = FALSE)
+
+# get predictions
+preds <- broom::augment(mod)
+# dput(round(preds$.fitted, 1))
+
+# plot
+ggplot(preds) +
+  geom_point(aes(temp, rate)) +
+  geom_line(aes(temp, .fitted)) +
+  theme_bw()
+
+# run test
+testthat::test_that("eubank_1973 function works", {
+  testthat::expect_equal(
+    round(preds$.fitted, 1),
+    c(0.2, 0.2, 0.3, 0.4, 0.6, 0.9, 1.3, 1.6, 1.4, 1, 0.7, 0.4))
+})
+```
+
+#### Getting results values
+
+The second-from-final line in the test file defines the expected return from a model run. It is not really feasible to know this ahead of time, but luckily the code here contains an extra function that makes retrieving the expected value easy.
+
+Before running the test for the first time, uncomment the line `dput(round(preds$.fitted, 1))`.
+
+Now when you run the test with `testthat::test_file("tests/testthat/test-eubank_1973.R")` then the test will very likely fail, but it will also output a vector to the console.
+
+```
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 0 ]c(0.2, 0.2, 0.3, 0.4, 0.6, 0.9, 1.3, 1.6, 1.4, 1, 0.7, 0.4)
+[ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
+
+── Failure (test-eubank_1973.R:39:3): eubank_1973 function works ───────────────
+round(preds$.fitted, 1) not equal to c(0.2, 0.3, 0.5, 0.6, 0.8, 1, 1.1, 1.2, 1.3, 1.2, 1, 0.1).
+11/12 mismatches (average diff: 0.209)
+[2]  0.2 - 0.3 == -0.1
+[3]  0.3 - 0.5 == -0.2
+[4]  0.4 - 0.6 == -0.2
+[5]  0.6 - 0.8 == -0.2
+[6]  0.9 - 1.0 == -0.1
+[7]  1.3 - 1.1 ==  0.2
+[8]  1.6 - 1.2 ==  0.4
+[9]  1.4 - 1.3 ==  0.1
+[10] 1.0 - 1.2 == -0.2
+...
+[ FAIL 1 | WARN 0 | SKIP 0 | PASS 0 ]
+```
+
+You can paste this vector (in this case `c(0.2, 0.2, 0.3, 0.4, 0.6, 0.9, 1.3, 1.6, 1.4, 1, 0.7, 0.4)`) onto the second from last line (remembering the extra closing parenthesis), then save and run again.
+
+On this second run the test should execute properly.
+
+```
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ]
+```
+
+You can then proceed with commenting back out the `dput()` line.
+
+### Finalisation
+
+Now you have fully implemented the model, there is a touch more housekeeping to do.
+
+Most notably the `_pkgdown.yaml` file contains the listing for the documentation index.
+
+To add your model to the documentation, add its name to the Models section:
+
+```
+reference:
+- title: Models
+  contents:
+  - analytiskontodimas_2004
+  - ashrafi1_2018
+  - ashrafi2_2018
+  ...
+  - warrendreyer_2006
+  - weibull_1995
+```
+
+_Note: YAML is a language where indentation is meaningful. Make sure your new entry is at the same indentation level as other models!_
+
+## Testing
+
+At this point it is worth doing a bit of testing of your new function.
+
+Load your new version of the package with `devtools::load_all(".")` and then in a new R (or Rmarkdown) file try running some tests with your new function.
+
+If you are having trouble with fitting, modify your starting values or limits and try again until you get fairly good fits.
+
+You may also have to play with the `iter` argument to `nls_multstart`.
+
+Once you are happy with everything it's time to run R CMD CHECK (for example using `devtools::check()`).
+
+Look to make sure that there are no warnings or errors.
+
+```
+── R CMD check results ──
+Duration: 4m 55.6s
+
+0 errors ✔ | 0 warnings ✔ | 0 notes ✔
+
+R CMD check succeeded
+```
+
+## Commiting your changes back upstream
+
+Now you have fully implemented your model it is time to hand it back to the rTPC team for integration.
+
+The simplest way to do this is to commit your changes, push those to your own forked repo, then open a pull request (a prompt should appear on your repo on the github website).
+
+Please make sure you include a sensible title such as "Add eubank_1976 model". 
+
+Include in the description any notes about the model itself, decisions you may have had to make when creating it, or problems and difficulties when fitting the model.
+
+See [PR #58 ](https://github.com/padpadpadpad/rTPC/pull/58) for an example of a good pull request.
+
+## Done!
+
+Now you are done and can go and have a well-earned cup of tea! You deserve it!
+
+---
+
+## Auxiliary model function dispatch
+
+_A note on **how** rTPC dispatches auxiliary model functions_
+
+Under the hood, rTPC relies on the `do.call()` function to locate and run the appropriate model functions.
+
+A good example of this is when getting starting values.
+
+The `get_start_vals()` function in its entirety is replicated here:
+
+```{r eval=FALSE, echo=TRUE}
+get_start_vals <- function(x, y, model_name) {
+
+  mod_names <- get_model_names(returnall = TRUE)
+  model_name <- tryCatch(rlang::arg_match(model_name, mod_names), error = function(e){
+    cli::cli_abort(c("x"="Supplied {.arg model_name} ({.val {model_name}}) is not an available model in rTPC.",
+                     "!"="Please check the spelling of {.arg model_name}.",
+                     " "="(run {.fn rTPC::get_model_names} to see all valid names.)",
+                     ""), call=rlang::caller_env(n=4))
+  })
+
+  # make data frame
+  d <- data.frame(x, y, stringsAsFactors = FALSE)
+  d <- d[order(d$x),]
+
+  start_vals <- tryCatch(do.call(paste0(model_name, ".starting_vals"), list(d=d)),
+                         error = function(e){NULL})
+
+  return(start_vals)
+}
+```
+
+Here the model name is checked against the list of valid models, and a source data frame (`d`) is created.
+
+Finally a model function name is created by pasting together the name of the model along with `".starting_vals"`:
+
+```{r}
+model_name <- "eubank_1976"
+paste0(model_name, ".starting_vals")
+```
+
+This function name is then executed using `do.call()` along with a list of arguments (in this case simply `d`), and the value is returned.
+
+If a model function is not present or is spelled incorrectly, `do.call()` will throw an error which the `tryCatch` will convert into a `NULL` output.
+
+In the case of an entirely missing model, `get_start_vals()` errors out early with a more specific error message.
+
+```{r tot_time, include=FALSE}
+tot_time <- lubridate::as.duration(lubridate::now() - runstart)
+```
+
+<span style="opacity: 0.1;font-size: small;">Built in `r tot_time`s</span>

--- a/vignettes/adding_models.Rmd
+++ b/vignettes/adding_models.Rmd
@@ -54,9 +54,15 @@ Adding a model to rTPC consists of 4 major steps:
 1. Add the model code, starting values, and limits.
 2. Add the test file.
 3. Add the model to the rTPC database.
-4. Clean up, check, and add to documentation
+4. Clean up and check.
 
-Models are generally named according to the scheme `authormodifier#_YYYY`. So a model by authors called King and Bishop published in 1992 would usually be codified as `kingbishop_1992`. If they further proposed a modified model, and a simplified version of each in the original paper, those would probably appear as `kingbishopmodified_1992`, `kingbishopsimplified_1992` and `kingbishopmodifiedsimplified_1992`. If there are many authors, or another better description of the model then initialisms or other descriptors can be used, but these may be changed if the package maintainers deem it to be confusing.
+Models are generally named according to the scheme `authormodifier#_YYYY`. So a model by authors called King and Bishop published in 1992 would usually be codified as `kingbishop_1992`. If they further proposed a modified model, and a simplified version of each in the original paper, those would probably appear as 
+
+- `kingbishopmodified_1992`
+- `kingbishopsimplified_1992`
+- `kingbishopmodifiedsimplified_1992`
+
+If there are many authors, or another better description of the model then initialisms or other descriptors can be used, but these may be changed if the package maintainers deem it to be confusing.
 
 ---
 
@@ -372,30 +378,6 @@ On this second run the test should execute properly.
 ```
 
 You can then proceed with commenting back out the `dput()` line.
-
----
-
-### Finalisation
-
-Now you have fully implemented the model, there is a touch more housekeeping to do.
-
-Most notably the `_pkgdown.yaml` file contains the listing for the documentation index.
-
-To add your model to the documentation, add its name to the Models section:
-
-```
-reference:
-- title: Models
-  contents:
-  - analytiskontodimas_2004
-  - ashrafi1_2018
-  - ashrafi2_2018
-  ...
-  - warrendreyer_2006
-  - weibull_1995
-```
-
-_Note: YAML is a language where indentation is meaningful. Make sure your new entry is at the same indentation level as other models!_
 
 ---
 

--- a/vignettes/adding_models.Rmd
+++ b/vignettes/adding_models.Rmd
@@ -23,11 +23,15 @@ knitr::opts_chunk$set(
 runstart <- lubridate::now()
 ```
 
+---
+
 ## First steps
 
 The first thing you want to do when you have a model that is potentially useful in rTPC is to _check whether it's already there_!
 
 rTPC already contains many models designed on a variety of different data. It is quite likely at this point that there is a similar (or identical) model that already serves the same purpose. So why not save yourself the work if you can?
+
+---
 
 ### Forking the repository
 
@@ -41,6 +45,8 @@ It is _strongly_ suggested that you install all packages from the "Suggests" sec
 
 Once you have done this, git clone from YOUR fork of rTPC into a folder of your choice, and then open up the `rTPC.Rproj` file if you are using RStudio.
 
+---
+
 ## Adding a model
 
 Adding a model to rTPC consists of 4 major steps:
@@ -51,6 +57,8 @@ Adding a model to rTPC consists of 4 major steps:
 4. Clean up, check, and add to documentation
 
 Models are generally named according to the scheme `authormodifier#_YYYY`. So a model by authors called King and Bishop published in 1992 would usually be codified as `kingbishop_1992`. If they further proposed a modified model, and a simplified version of each in the original paper, those would probably appear as `kingbishopmodified_1992`, `kingbishopsimplified_1992` and `kingbishopmodifiedsimplified_1992`. If there are many authors, or another better description of the model then initialisms or other descriptors can be used, but these may be changed if the package maintainers deem it to be confusing.
+
+---
 
 ### The model
 
@@ -68,6 +76,8 @@ $$R(T) = \frac{a}{(T-T_{opt})^2+b}$$
 
 Where $a$ and $b$ are arbitrary parameters for fitting, and $T_{opt}$ can be at least approximated from the data.
 
+---
+
 ### The model file
 
 The model itself lives in a file named after the function, in the `R` directory. In our case that will be `eubank_1973.R`.
@@ -83,6 +93,8 @@ Within this file are 4 functions:
 
 It is _very important_ that the auxiliary functions are named in this manner, otherwise the unified starting value/limit dispatch will not function correctly.
 
+---
+
 #### The model function - `eubank_1973()`
 
 First of all we must implement the actual model itself (i.e. the equation above, but as R code).
@@ -95,6 +107,8 @@ eubank_1973 <- function(temp, topt, a, b){
 ```
 
 A model function takes the parameters to fit the model as arguments, with temperature being the first by convention, and returns the estimates of the trait value at the given temperatures and parameter values.
+
+---
 
 #### The starting values - `eubank_1973.starting_vals()`
 
@@ -146,6 +160,8 @@ The following _will not and can not work_:
 - `.starting_vals()`
 - `model.starting_vals()`
 
+---
+
 #### The limits - `eubank_1973.lower_lims()` & `eubank_1973.upper_lims()`
 
 NLLS fitting often fails when unconstrained (as it may take one parameter to infinity and ignore all others). Even specifying absurdly large or infinite limits can make the optimiser behave better.
@@ -180,6 +196,8 @@ eubank_1973.upper_lims <- function(d){
 }
 ```
 
+---
+
 #### The documentation
 
 rTPC leverages `roxygen2` for documentation. Each file contains documentation definitions at the **top of the file** in special comments starting `#'`.
@@ -187,6 +205,7 @@ rTPC leverages `roxygen2` for documentation. Each file contains documentation de
 The best way to implement these is to copy from another model file (such as `atkin_2005`) and modify it to suit your own needs.
 
 Things to modify:
+
 - The first line description
 - parameters
 - author
@@ -196,11 +215,15 @@ Things to modify:
 - examples
 - export directive (this _must_ match the name of the model! The starting value and limit functions do not need exporting)
 
+---
+
 ### The model database
 
 Once you have created a model file, you need to add this model to rTPC's database of model names, so it knows that the model is available.
 
 This simply requires modifying the `mod_names` vector within the `get_model_names.R` file to include your new model. Make sure that the model name is exactly the same as that in your original file, and that it is enclosed in quotes!
+
+---
 
 ### Testing the model
 
@@ -245,6 +268,8 @@ In this case we can see that I simply misspelled the name of the model in the `g
 
 If only one test of the three failed, that is likely an issue with the names of the functions in the actual model file.
 
+---
+
 ### The model test file
 
 Each model requires a model test, to make sure that changes in the future do not cause major fitting issues. These test files live in the `tests/testthat` directory.
@@ -256,9 +281,10 @@ This will create a new test file, in our case `tests/testthat/test-eubank_1973.R
 Tests are mostly boilerplate, however there are a few things that do need to be changed, so again you can copy most of the code from another test file, such as `test-atkin_2005.R`.
 
 The main items to be changed are:
+
 - The model name throughout (5 occurrences)
 - The model arguments within `nls_multstart`
-- The `iter` argument to `nls_multstart` (this should be something like c(3,3,3,3) for a model with 4 free parameters)
+- The `iter` argument to `nls_multstart` (this should be something like `c(3,3,3,3)` for a model with 4 free parameters)
 
 So the final test file will look something like this:
 
@@ -307,6 +333,8 @@ testthat::test_that("eubank_1973 function works", {
 })
 ```
 
+---
+
 #### Getting results values
 
 The second-from-final line in the test file defines the expected return from a model run. It is not really feasible to know this ahead of time, but luckily the code here contains an extra function that makes retrieving the expected value easy.
@@ -345,6 +373,8 @@ On this second run the test should execute properly.
 
 You can then proceed with commenting back out the `dput()` line.
 
+---
+
 ### Finalisation
 
 Now you have fully implemented the model, there is a touch more housekeeping to do.
@@ -366,6 +396,8 @@ reference:
 ```
 
 _Note: YAML is a language where indentation is meaningful. Make sure your new entry is at the same indentation level as other models!_
+
+---
 
 ## Testing
 
@@ -390,17 +422,31 @@ Duration: 4m 55.6s
 R CMD check succeeded
 ```
 
+---
+
+## Documenting your model
+
+Documentation needs to be generated in order to be available for your own model.
+
+To do this, simply run the command `devtools::document()`.
+
+Once this has completed you can view your documentation internally using `?modelname_yyyy`.
+
+---
+
 ## Commiting your changes back upstream
 
 Now you have fully implemented your model it is time to hand it back to the rTPC team for integration.
 
-The simplest way to do this is to commit your changes, push those to your own forked repo, then open a pull request (a prompt should appear on your repo on the github website).
+The simplest way to do this is to commit your changes (including the .Rd documentation file), push those to your own forked repo, then open a pull request (a prompt should appear on your repo on the github website).
 
 Please make sure you include a sensible title such as "Add eubank_1976 model". 
 
 Include in the description any notes about the model itself, decisions you may have had to make when creating it, or problems and difficulties when fitting the model.
 
 See [PR #58 ](https://github.com/padpadpadpad/rTPC/pull/58) for an example of a good pull request.
+
+---
 
 ## Done!
 

--- a/vignettes/adding_models.Rmd
+++ b/vignettes/adding_models.Rmd
@@ -66,7 +66,7 @@ If there are many authors, or another better description of the model then initi
 
 ---
 
-### The model
+### Model equation
 
 For this example, let's implement the Eubank model from [The Significance and Thermodynamics of Fluctuating Versus Static Thermal Environments on _Heliothis zea_ Egg Development Rates](https://academic.oup.com/ee/article/2/4/491/2480483).
 
@@ -84,7 +84,7 @@ Where $a$ and $b$ are arbitrary parameters for fitting, and $T_{opt}$ can be at 
 
 ---
 
-### The model file
+### Implementation
 
 The model itself lives in a file named after the function, in the `R` directory. In our case that will be `eubank_1973.R`.
 
@@ -101,7 +101,7 @@ It is _very important_ that the auxiliary functions are named in this manner, ot
 
 ---
 
-#### The model function - `eubank_1973()`
+#### Model function - `eubank_1973()`
 
 First of all we must implement the actual model itself (i.e. the equation above, but as R code).
 
@@ -116,7 +116,7 @@ A model function takes the parameters to fit the model as arguments, with temper
 
 ---
 
-#### The starting values - `eubank_1973.starting_vals()`
+#### Starting values - `eubank_1973.starting_vals()`
 
 Deciding sensible starting values is truly a dark art. In many cases these are fairly arbitrary, though in certain cases an estimate can be obtained from the data.
 
@@ -160,6 +160,7 @@ eubank_1973.starting_vals <- function(d){
 To reiterate an earlier point, it is _essential_ that the starting values function is named appropriately, e.g. `eubank_1973.starting_vals()`.
 
 The following _will not and can not work_:
+
 - `eubank_1973.startingvals()`
 - `eubank_1973.start_vals()`
 - `eubank_1973_starting_vals()`
@@ -168,7 +169,7 @@ The following _will not and can not work_:
 
 ---
 
-#### The limits - `eubank_1973.lower_lims()` & `eubank_1973.upper_lims()`
+#### Limits - `eubank_1973.lower_lims()` & `eubank_1973.upper_lims()`
 
 NLLS fitting often fails when unconstrained (as it may take one parameter to infinity and ignore all others). Even specifying absurdly large or infinite limits can make the optimiser behave better.
 
@@ -204,7 +205,7 @@ eubank_1973.upper_lims <- function(d){
 
 ---
 
-#### The documentation
+#### Documentation
 
 rTPC leverages `roxygen2` for documentation. Each file contains documentation definitions at the **top of the file** in special comments starting `#'`.
 
@@ -223,7 +224,7 @@ Things to modify:
 
 ---
 
-### The model database
+### Updating the model database
 
 Once you have created a model file, you need to add this model to rTPC's database of model names, so it knows that the model is available.
 
@@ -231,7 +232,7 @@ This simply requires modifying the `mod_names` vector within the `get_model_name
 
 ---
 
-### Testing the model
+### Testing model implementation
 
 Now that the model is set up, the next port of call is to simply run the integration test.
 
@@ -276,7 +277,7 @@ If only one test of the three failed, that is likely an issue with the names of 
 
 ---
 
-### The model test file
+### Individual model test
 
 Each model requires a model test, to make sure that changes in the future do not cause major fitting issues. These test files live in the `tests/testthat` directory.
 


### PR DESCRIPTION
This PR enacts three major changes to rTPC:

1. Add a first attempt at an **"adding models" vignette**
2. Enables **light switch** (dark mode toggle) in rendered pkgdown documentation
3. Fully **reworks** how documentation is indexed (using the has_concept directive of pkgdown)

After this PR is merged, new models or functions will no longer need to be manually added to `_pkgdown.yaml`. Instead an extra roxygen tag called `@concept` is used. There are currently 4 concepts that code files tend to come under (modelled after the original documentation split):

- `model` - model files
- `helper` - helper functions to aid in fitting
- `params` - functions to derive extra parameters of interest
- `data` - data files provided with rTPC

In practical terms this change should make little difference to the documentation site itself, but under the hood it removes one more edit that a developer needs to remember to do when adding a new model to rTPC. As long as they remember to add `@concept model` to the documentation, everything else is automatic now.

