### PR TITLE
Fix documentation colouring

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,6 @@
 template:
   bootstrap: 5
   light-switch: true
-  bootswatch: cosmo
   math-rendering: mathjax
   bslib:
     font_scale: 1


### PR DESCRIPTION
This PR fixes incorrect colouration in light mode for the pkgdown documentation website. (Fixing #70)

Can't see any unintended side effects, but if there are any we can probably patch it back in some form later.